### PR TITLE
fix: OIDC publish + lockfile sync

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,11 @@ on:
 
 concurrency: release
 
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write # OIDC — required for npm Trusted Publisher
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -19,34 +24,14 @@ jobs:
           node-version: 22
           cache: pnpm
           registry-url: https://registry.npmjs.org
-
-      - name: Configure npm registry auth
-        run: |
-          if [ -z "${NPM_TOKEN:-}" ]; then
-            echo "::error::NPM_TOKEN secret is not set on this repo. Add it under Settings → Secrets and variables → Actions."
-            exit 1
-          fi
-          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
-          echo "registry=https://registry.npmjs.org/" >> ~/.npmrc
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Verify npm identity
-        run: |
-          WHOAMI=$(npm whoami 2>&1 || echo "ANON")
-          echo "npm whoami → ${WHOAMI}"
-          if [ "${WHOAMI}" = "ANON" ] || [[ "${WHOAMI}" == *"Unable to authenticate"* ]]; then
-            echo "::error::npm auth failed. Your NPM_TOKEN is invalid or expired. Create a new 'Automation' or 'Granular' token at https://www.npmjs.com/settings/<username>/tokens with publish access to @rogeroliveira84 scope."
-            exit 1
-          fi
-
+      - name: Upgrade npm for OIDC trusted publishing (requires >= 11.5.1)
+        run: npm install -g npm@latest
       - run: pnpm install --frozen-lockfile
-
-      - uses: changesets/action@v1
+      - name: Run release
+        uses: changesets/action@v1
         with:
           publish: pnpm release
           version: pnpm version-packages
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: 'true'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,7 +59,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^4.3.3
-        version: 4.7.0(vite@6.4.2(jiti@1.21.7))
+        version: 4.7.0(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7))
       autoprefixer:
         specifier: ^10.4.20
         version: 10.5.0(postcss@8.5.10)
@@ -74,7 +74,68 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^6.4.2
-        version: 6.4.2(jiti@1.21.7)
+        version: 6.4.2(@types/node@22.19.17)(jiti@1.21.7)
+
+  apps/docs:
+    dependencies:
+      '@ai-sdk/anthropic':
+        specifier: ^1.0.6
+        version: 1.2.12(zod@3.25.76)
+      '@rogeroliveira84/react-dynamic-forms':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@rogeroliveira84/react-dynamic-forms-ai':
+        specifier: workspace:*
+        version: link:../../packages/ai
+      '@rogeroliveira84/react-dynamic-forms-ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
+      ai:
+        specifier: ^4.0.14
+        version: 4.3.19(react@19.2.5)(zod@3.25.76)
+      geist:
+        specifier: ^1.3.1
+        version: 1.7.0(next@15.5.15(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
+      lucide-react:
+        specifier: ^0.460.0
+        version: 0.460.0(react@19.2.5)
+      next:
+        specifier: ^15.1.0
+        version: 15.5.15(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.5(react@19.2.5)
+      react-hook-form:
+        specifier: ^7.53.2
+        version: 7.72.1(react@19.2.5)
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^22.9.3
+        version: 22.19.17
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.14)
+      autoprefixer:
+        specifier: ^10.4.20
+        version: 10.5.0(postcss@8.5.10)
+      postcss:
+        specifier: ^8.4.49
+        version: 8.5.10
+      tailwindcss:
+        specifier: ^3.4.15
+        version: 3.4.19
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
 
   packages/ai:
     devDependencies:
@@ -4962,7 +5023,7 @@ snapshots:
       '@typescript-eslint/types': 8.58.2
       eslint-visitor-keys: 5.0.1
 
-  '@vitejs/plugin-react@4.7.0(vite@6.4.2(jiti@1.21.7))':
+  '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -4970,7 +5031,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.4.2(jiti@1.21.7)
+      vite: 6.4.2(@types/node@22.19.17)(jiti@1.21.7)
     transitivePeerDependencies:
       - supports-color
 
@@ -6555,7 +6616,7 @@ snapshots:
       '@types/node': 22.19.17
       fsevents: 2.3.3
 
-  vite@6.4.2(jiti@1.21.7):
+  vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
@@ -6564,10 +6625,11 @@ snapshots:
       rollup: 4.60.2
       tinyglobby: 0.2.16
     optionalDependencies:
+      '@types/node': 22.19.17
       fsevents: 2.3.3
       jiti: 1.21.7
 
-  vitest@2.1.9(jsdom@25.0.1):
+  vitest@2.1.9(@types/node@22.19.17)(jsdom@25.0.1):
     dependencies:
       '@vitest/expect': 2.1.9
       '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@22.19.17))


### PR DESCRIPTION
## Two bundled fixes

### 1. Release workflow → OIDC Trusted Publisher
Previous `release.yml` (from PR #36) still required `NPM_TOKEN`. You configured **Trusted Publisher** on npm, so we don't need a token at all. This PR:
- Adds `permissions: id-token: write`
- Drops `NPM_TOKEN` references
- Upgrades npm CLI in the runner (Node 22 ships 10.x; OIDC needs ≥ 11.5.1)
- Sets `NPM_CONFIG_PROVENANCE: 'true'` so each release gets a signed provenance badge on npmjs.com

### 2. `pnpm-lock.yaml` resync
`apps/docs` deps were never committed to the lockfile, which made `pnpm install --frozen-lockfile` fail in CI with `ERR_PNPM_OUTDATED_LOCKFILE`.

## You still need to do (one-time)

1. Bootstrap `@rogeroliveira84/react-dynamic-forms-ui` with a single manual publish (it doesn't exist on npm yet; Trusted Publisher can't be configured on non-existent packages):
   ```bash
   pnpm -w turbo build --filter=./packages/ui
   cd packages/ui && npm publish --access public
   ```
   This asks for your 2FA OTP once; after that the package exists on npm.
2. Go to https://www.npmjs.com/package/@rogeroliveira84/react-dynamic-forms-ui/access → **Trusted Publisher** → configure identically to the core package.
3. Merge this PR. Release workflow re-runs on master push and both packages publish via OIDC with provenance — no OTP, no token.

## Verification after merge

Actions → Release → expect:
- `info Publishing "@rogeroliveira84/react-dynamic-forms" at "1.0.0"`
- `info Publishing "@rogeroliveira84/react-dynamic-forms-ui" at "1.0.0"`
- `✓ Released!`
- Visit npmjs.com — both packages at 1.0.0 with the 🛡️ provenance badge.