### PR TITLE
fix(changeset): drop ignored -ai from v2 changeset

### DIFF
--- a/.changeset/v2-ai-launch.md
+++ b/.changeset/v2-ai-launch.md
@@ -1,17 +1,16 @@
 ---
 '@rogeroliveira84/react-dynamic-forms': minor
 '@rogeroliveira84/react-dynamic-forms-ui': minor
-'@rogeroliveira84/react-dynamic-forms-ai': minor
 ---
 
 # v2 — AI launch 🤖
 
 ## New
 
-- **`@rogeroliveira84/react-dynamic-forms-ai`** ships for real. `generateSchema({ from, prompt, model })` turns natural language, TypeScript, or a JSON sample into an `InternalSchema` + ready-to-paste Zod code + JSON Schema. Built on the Vercel AI SDK, provider-agnostic (Anthropic / OpenAI / Google / anything `LanguageModelV1`).
 - **`file` field kind** — single/multiple file upload with `accept`, `maxSize`, preview, remove, Zod `instanceof(File)` validation.
 - **`showIf` conditional fields** — any field can declare `showIf: { field, equals }` to render only when a dependency matches. Honored by JSON Schema adapter via `x-rdf-show-if` extension.
 - **`internalToZod`** re-exported from core (consumed by the AI package's emitter; also useful for anyone who wants a Zod schema at runtime without relying on a Zod-native source).
+- Sister package **`@rogeroliveira84/react-dynamic-forms-ai`** (AI-powered schema generation built on the Vercel AI SDK) is available separately — see its own release.
 
 ## Changed
 


### PR DESCRIPTION
The v2 changeset listed `@rogeroliveira84/react-dynamic-forms-ai` as a minor bump, but that package is also in `.changeset/config.json → ignore` (because it's `private: true`). Changesets rejects mixed changesets:

```
Mixed changet contain both ignored and not ignored packages are not allowed
```

Fix: drop `-ai` from the changeset. Core + ui still bump to 1.1.0 as planned. When we decide to ship the AI package, we flip its `private` field and write a separate changeset for it.