### PR TITLE
feat: multi-step wizard, async combobox, and i18n

### DIFF
--- a/.changeset/power-features.md
+++ b/.changeset/power-features.md
@@ -1,0 +1,22 @@
+---
+'@rogeroliveira84/react-dynamic-forms': minor
+'@rogeroliveira84/react-dynamic-forms-ui': minor
+---
+
+# Power features — wizard, async combobox, i18n
+
+## New
+
+- **Multi-step wizard** — `<DynamicForm.Wizard steps={[...]}>` (also exported as `FormWizard`). One underlying form across steps; "Next" validates only the current step's fields via `form.trigger`, with a built-in progress indicator and a dev warning when steps don't cover all fields.
+- **Combobox** — new `combobox` field kind: a searchable single-select. Supply async options at render with `<DynamicForm asyncOptions={{ field: (query) => Promise<EnumOption[]> }}>` and any field (even a plain `z.string()`) becomes a debounced, keyboard-navigable async combobox. Detected from JSON Schema via the `x-rdf-combobox` extension.
+- **i18n** — localize all validation messages with a single `locale` prop (`'en' | 'pt-BR' | 'es'`, or a custom message object). Per-key overrides via `messages`. Messages set explicitly on the schema still win. Implemented as a Zod `errorMap`, so it works for Zod, JSON Schema, and legacy inputs alike.
+
+## Changed
+
+- `core` `FieldKind` union gained `combobox`; `JsonSchema` accepts `x-rdf-combobox`.
+- `core` exports the i18n helpers (`createErrorMap`, `resolveMessages`, locale packs) and `RdfLocaleInput` / `RdfMessages` types.
+- `ui` `<DynamicForm>` gained `locale`, `messages`, and `asyncOptions` props (all optional, fully backward compatible).
+
+## Notes
+
+- One new dependency in `ui`: `@radix-ui/react-popover` (powers the combobox). Wizard and i18n add no dependencies.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # 🎛️ React Dynamic Forms
 
-### Zod-powered dynamic React forms. Type-safe. AI-ready.
+### Zod-powered dynamic React forms. Type-safe. Tiny.
 
 [![npm version](https://img.shields.io/npm/v/@rogeroliveira84/react-dynamic-forms?color=blue&label=npm)](https://www.npmjs.com/package/@rogeroliveira84/react-dynamic-forms)
 [![bundle size](https://img.shields.io/bundlephobia/minzip/@rogeroliveira84/react-dynamic-forms?label=gzipped)](https://bundlephobia.com/package/@rogeroliveira84/react-dynamic-forms)
@@ -42,7 +42,9 @@ export function SignupForm() {
 - 🎨 **Beautiful** — shadcn/ui out of the box, fully themeable via CSS variables.
 - ♿ **Accessible** — WCAG AA, keyboard-first, ARIA-correct, dark-mode ready.
 - 🔀 **Hybrid input** — accepts **Zod schemas**, **JSON Schema Draft 2020-12**, or **legacy v0.5 config**.
-- 🤖 **AI-powered** — `generateSchema({ prompt, model })` turns plain English into a validated Zod schema in one call.
+- 🧙 **Multi-step wizard** — split any schema into validated steps with one component.
+- 🔎 **Async combobox** — searchable selects backed by remote data, no extra wiring.
+- 🌍 **i18n** — localize every validation message with a single `locale` prop.
 
 ## 📦 Install
 
@@ -54,34 +56,49 @@ pnpm add @rogeroliveira84/react-dynamic-forms @rogeroliveira84/react-dynamic-for
 
 | Input                              | Example                                           | Status          |
 |------------------------------------|---------------------------------------------------|-----------------|
-| **Zod**                            | `z.object({ ... })`                               | ✅ v1           |
-| **JSON Schema Draft 2020-12**      | `{ type: 'object', properties: { ... } }`         | ✅ v1           |
+| **Zod**                            | `z.object({ ... })`                               | ✅              |
+| **JSON Schema Draft 2020-12**      | `{ type: 'object', properties: { ... } }`         | ✅              |
 | **Legacy v0.5 config**             | `{ fields: [{ id, label, type, ... }] }`          | ⚠️ deprecated  |
-| **AI prompt → schema**             | `generateSchema({ prompt: '...' })`                | 🔜 v2           |
 
 ## 🧱 Supported field kinds
 
-`text` · `email` · `password` · `url` · `number` · `slider` · `textarea` · `boolean` · `date` · `datetime` · `time` · `enum` · `multi-enum` · `object` *(nested)* · `array` *(repeater)* · `file` · plus `showIf` conditional fields on any kind.
+`text` · `email` · `password` · `url` · `number` · `slider` · `textarea` · `boolean` · `date` · `datetime` · `time` · `enum` · `multi-enum` · `combobox` *(static or async)* · `object` *(nested)* · `array` *(repeater)* · `file` · plus `showIf` conditional fields on any kind.
 
-Coming next: `combobox` *(async)*, `richtext`, `multi-step wizard`, i18n.
+## 🧙 Multi-step wizard
 
-## 🤖 AI schema generation
+Split a single schema into validated steps. One form underneath — values persist as you navigate, and **Next** won't advance while the current step is invalid.
 
 ```tsx
-import { generateSchema } from '@rogeroliveira84/react-dynamic-forms-ai'
-import { DynamicForm } from '@rogeroliveira84/react-dynamic-forms-ui'
-import { anthropic } from '@ai-sdk/anthropic'
-
-const { internalSchema, zodCode } = await generateSchema({
-  from: 'text',
-  prompt: 'A job application form for software engineers with portfolio and years of experience',
-  model: anthropic('claude-sonnet-4-6'),
-})
-
-<DynamicForm schema={internalSchema} onSubmit={(data) => console.log(data)} />
+<DynamicForm.Wizard
+  schema={schema}
+  steps={[
+    { title: 'Account', fields: ['email', 'password'] },
+    { title: 'Profile', fields: ['name', 'age'] },
+  ]}
+  onSubmit={(data) => console.log(data)}
+/>
 ```
 
-Server-side only — never expose API keys to the browser. Works with any `@ai-sdk/*` provider (Anthropic, OpenAI, Google, Mistral, Groq, etc.).
+## 🔎 Combobox with async options
+
+Any field with an async loader becomes a searchable, debounced, keyboard-navigable combobox — even a plain `z.string()`.
+
+```tsx
+<DynamicForm
+  schema={z.object({ city: z.string() })}
+  asyncOptions={{ city: (query) => fetchCities(query) }}
+/>
+```
+
+For static lists, declare a combobox in JSON Schema with the `x-rdf-combobox` extension.
+
+## 🌍 Internationalized validation
+
+One prop localizes every validation message. Built-in `en`, `pt-BR`, and `es`; override individual messages with `messages`, or pass your own message object. Messages set explicitly on the schema always win.
+
+```tsx
+<DynamicForm schema={schema} locale="pt-BR" />
+```
 
 ## 🎨 Styling & theming
 
@@ -98,29 +115,32 @@ The defaults ship in `@rogeroliveira84/react-dynamic-forms-ui/styles.css`. The `
 
 ## 🧭 Comparison
 
-| Feature                            | RDF v1     | RJSF | JSON Forms | react-hook-form |
+| Feature                            | RDF        | RJSF | JSON Forms | react-hook-form |
 |------------------------------------|------------|------|------------|-----------------|
 | Zod schema input                   | ✅         | ❌   | ❌         | ✅              |
 | JSON Schema input                  | ✅         | ✅   | ✅         | ❌              |
 | shadcn/ui out of the box           | ✅         | ❌   | ❌         | ❌              |
 | TypeScript inference of form data  | ✅         | ⚠️   | ⚠️         | ✅              |
+| Multi-step wizard                  | ✅         | ❌   | ⚠️         | DIY             |
+| Async combobox                     | ✅         | ⚠️   | ⚠️         | DIY             |
+| Localized validation               | ✅         | ⚠️   | ✅         | DIY             |
 | Bundle size (gzip, core)           | < 15 kb    | ~60 kb | ~80 kb   | ~9 kb           |
-| AI-powered generation (planned)    | ✅ v2      | ❌   | ❌         | ❌              |
 
 *Bundle numbers are approximations from Bundlephobia. All these libs are great — this table is about fit.*
 
 ## 📚 Docs
 
-- [Live playground](https://rdf.dev) *(coming soon)*
 - [Migration from v0.5](./docs/migrate-from-v0.md)
 - [Design spec](./docs/superpowers/specs/2026-04-19-rdf-modernization-design.md)
+- [Power features spec](./docs/superpowers/specs/2026-06-05-rdf-power-features-design.md)
 
 ## 🗺️ Roadmap
 
-- [x] **v1.0** — Foundation (Zod + JSON Schema + shadcn + RHF)
-- [ ] **v1.1** — `file`, `combobox`, `conditional`
-- [ ] **v2.0** — AI generator (`prompt → schema`), multi-step wizard, i18n
-- [ ] **v3.0** — Visual form builder *(maybe)*
+- [x] **Foundation** — Zod + JSON Schema + shadcn + RHF
+- [x] **File upload + conditional fields** (`showIf`)
+- [x] **Multi-step wizard · async combobox · i18n**
+- [ ] **Multi-select combobox · rich text**
+- [ ] **Visual form builder** *(maybe)*
 
 ## 🤝 Contributing
 

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -2,7 +2,7 @@
 
 # 🎛️ React Dynamic Forms
 
-### Formulários React dinâmicos com Zod. Type-safe. Prontos pra IA.
+### Formulários React dinâmicos com Zod. Type-safe. Pequenos.
 
 [![npm](https://img.shields.io/npm/v/@rogeroliveira84/react-dynamic-forms?color=blue&label=npm)](https://www.npmjs.com/package/@rogeroliveira84/react-dynamic-forms)
 [![tamanho](https://img.shields.io/bundlephobia/minzip/@rogeroliveira84/react-dynamic-forms?label=gzipped)](https://bundlephobia.com/package/@rogeroliveira84/react-dynamic-forms)
@@ -41,7 +41,9 @@ export function CadastroForm() {
 - 🎨 **Bonito** — shadcn/ui por padrão, tema via CSS variables.
 - ♿ **Acessível** — WCAG AA, teclado, ARIA, dark mode.
 - 🔀 **Múltiplos formatos de entrada** — Zod, JSON Schema 2020-12, config legado v0.5.
-- 🤖 **Pronto pra IA** *(v2)* — prompt → schema → form em segundos.
+- 🧙 **Wizard multi-etapa** — divida qualquer schema em etapas validadas com um componente.
+- 🔎 **Combobox assíncrono** — selects com busca alimentados por dados remotos.
+- 🌍 **i18n** — traduza todas as mensagens de validação com uma única prop `locale`.
 
 ## 📦 Instalação
 
@@ -53,21 +55,62 @@ pnpm add @rogeroliveira84/react-dynamic-forms @rogeroliveira84/react-dynamic-for
 
 | Entrada                            | Exemplo                                           | Status          |
 |------------------------------------|---------------------------------------------------|-----------------|
-| **Zod**                            | `z.object({ ... })`                               | ✅ v1           |
-| **JSON Schema Draft 2020-12**      | `{ type: 'object', properties: { ... } }`         | ✅ v1           |
+| **Zod**                            | `z.object({ ... })`                               | ✅              |
+| **JSON Schema Draft 2020-12**      | `{ type: 'object', properties: { ... } }`         | ✅              |
 | **Config legado v0.5**             | `{ fields: [{ id, label, type, ... }] }`          | ⚠️ obsoleto    |
-| **Prompt → schema (IA)**           | `generateSchema({ prompt: '...' })`                | 🔜 v2           |
 
 ## 🧱 Tipos de campo suportados
 
-`text` · `email` · `password` · `url` · `number` · `slider` · `textarea` · `boolean` · `date` · `datetime` · `time` · `enum` · `multi-enum` · `object` *(aninhado)* · `array` *(lista repetida)*
+`text` · `email` · `password` · `url` · `number` · `slider` · `textarea` · `boolean` · `date` · `datetime` · `time` · `enum` · `multi-enum` · `combobox` *(estático ou async)* · `object` *(aninhado)* · `array` *(lista repetida)* · `file` · mais campos condicionais `showIf` em qualquer tipo.
 
-Em breve (v2): `combobox` *(async)*, `file`, `richtext`, `condicional`, `wizard multi-etapa`.
+## 🧙 Wizard multi-etapa
+
+Divida um único schema em etapas validadas. Um form por baixo — os valores persistem ao navegar, e o **Próximo** não avança enquanto a etapa atual estiver inválida.
+
+```tsx
+<DynamicForm.Wizard
+  schema={schema}
+  steps={[
+    { title: 'Conta', fields: ['email', 'senha'] },
+    { title: 'Perfil', fields: ['nome', 'idade'] },
+  ]}
+  onSubmit={(data) => console.log(data)}
+/>
+```
+
+## 🔎 Combobox com opções assíncronas
+
+Qualquer campo com um loader assíncrono vira um combobox com busca, debounce e navegação por teclado — até um simples `z.string()`.
+
+```tsx
+<DynamicForm
+  schema={z.object({ cidade: z.string() })}
+  asyncOptions={{ cidade: (busca) => buscarCidades(busca) }}
+/>
+```
+
+Para listas estáticas, declare um combobox no JSON Schema com a extensão `x-rdf-combobox`.
+
+## 🌍 Validação internacionalizada
+
+Uma prop traduz todas as mensagens de validação. Pacotes embutidos `en`, `pt-BR` e `es`; sobrescreva mensagens específicas com `messages`, ou passe seu próprio objeto de mensagens. Mensagens definidas direto no schema sempre vencem.
+
+```tsx
+<DynamicForm schema={schema} locale="pt-BR" />
+```
 
 ## 📚 Documentação
 
-- [Playground ao vivo](https://rdf.dev) *(em breve)*
 - [Migração da v0.5](./docs/migrate-from-v0.md)
+- [Design spec (EN)](./docs/superpowers/specs/2026-04-19-rdf-modernization-design.md)
+
+## 🗺️ Roadmap
+
+- [x] **Fundação** — Zod + JSON Schema + shadcn + RHF
+- [x] **Upload de arquivo + campos condicionais** (`showIf`)
+- [x] **Wizard multi-etapa · combobox assíncrono · i18n**
+- [ ] **Combobox multi-seleção · rich text**
+- [ ] **Construtor visual de formulários** *(talvez)*
 
 ## 🤝 Contribuição
 

--- a/apps/demo/src/App.tsx
+++ b/apps/demo/src/App.tsx
@@ -1,14 +1,56 @@
-import { useState } from 'react'
+import { useState, type ReactNode } from 'react'
 import { DynamicForm } from '@rogeroliveira84/react-dynamic-forms-ui'
 import { zodExample } from './examples/zod-example'
 import { jsonSchemaExample } from './examples/json-schema-example'
 import { legacyExample } from './examples/legacy-example'
+import { wizardSchema, wizardSteps } from './examples/wizard-example'
+import { comboboxSchema, loadCountries } from './examples/combobox-example'
+
+type Submit = (data: unknown) => void
+type TabDef = { label: string; blurb: string; render: (onSubmit: Submit) => ReactNode }
 
 const tabs = {
-  zod: { label: 'Zod', schema: zodExample },
-  json: { label: 'JSON Schema', schema: jsonSchemaExample },
-  legacy: { label: 'Legacy v0.5', schema: legacyExample },
-} as const
+  zod: {
+    label: 'Zod',
+    blurb: 'A Zod schema in, a validated form out.',
+    render: (onSubmit) => <DynamicForm schema={zodExample} onSubmit={onSubmit} />,
+  },
+  json: {
+    label: 'JSON Schema',
+    blurb: 'JSON Schema Draft 2020-12 for backend interop.',
+    render: (onSubmit) => <DynamicForm schema={jsonSchemaExample} onSubmit={onSubmit} />,
+  },
+  legacy: {
+    label: 'Legacy v0.5',
+    blurb: 'Old config format still works (with a deprecation warning).',
+    render: (onSubmit) => <DynamicForm schema={legacyExample} onSubmit={onSubmit} />,
+  },
+  wizard: {
+    label: 'Wizard',
+    blurb: 'Multi-step form. Each step validates before you can advance.',
+    render: (onSubmit) => (
+      <DynamicForm.Wizard schema={wizardSchema} steps={wizardSteps} onSubmit={onSubmit} />
+    ),
+  },
+  combobox: {
+    label: 'Combobox (async)',
+    blurb: 'A plain z.string() upgraded to a searchable async combobox via asyncOptions.',
+    render: (onSubmit) => (
+      <DynamicForm
+        schema={comboboxSchema}
+        asyncOptions={{ country: loadCountries }}
+        onSubmit={onSubmit}
+      />
+    ),
+  },
+  i18n: {
+    label: 'i18n (pt-BR)',
+    blurb: 'Same schema, validation messages localized with a single locale prop.',
+    render: (onSubmit) => (
+      <DynamicForm schema={zodExample} locale="pt-BR" submitLabel="Enviar" onSubmit={onSubmit} />
+    ),
+  },
+} satisfies Record<string, TabDef>
 
 type Tab = keyof typeof tabs
 
@@ -21,11 +63,11 @@ export default function App() {
       <header className="mb-8">
         <h1 className="text-3xl font-bold">React Dynamic Forms</h1>
         <p className="text-muted-foreground">
-          Zod-powered dynamic React forms. Try each schema input below.
+          Zod-powered dynamic React forms. Try each schema input and feature below.
         </p>
       </header>
 
-      <nav className="mb-6 flex gap-2 border-b border-border pb-2">
+      <nav className="mb-6 flex flex-wrap gap-2 border-b border-border pb-2">
         {(Object.keys(tabs) as Tab[]).map((t) => (
           <button
             key={t}
@@ -42,15 +84,15 @@ export default function App() {
         ))}
       </nav>
 
+      <p className="mb-4 text-sm text-muted-foreground">{tabs[tab].blurb}</p>
+
       <section className="rounded-md border border-border p-6">
-        <DynamicForm schema={tabs[tab].schema} onSubmit={(data) => setOutput(data)} />
+        {tabs[tab].render((data) => setOutput(data))}
       </section>
 
       {output !== null && (
         <section className="mt-6 rounded-md border border-border p-4">
-          <h3 className="mb-2 text-sm font-semibold uppercase text-muted-foreground">
-            Submitted
-          </h3>
+          <h3 className="mb-2 text-sm font-semibold uppercase text-muted-foreground">Submitted</h3>
           <pre className="overflow-auto text-xs">{JSON.stringify(output, null, 2)}</pre>
         </section>
       )}

--- a/apps/demo/src/examples/combobox-example.ts
+++ b/apps/demo/src/examples/combobox-example.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod'
+import type { EnumOption } from '@rogeroliveira84/react-dynamic-forms'
+
+export const comboboxSchema = z.object({
+  country: z.string().describe('Start typing to search countries'),
+})
+
+const COUNTRIES: EnumOption[] = [
+  { value: 'br', label: 'Brazil' },
+  { value: 'us', label: 'United States' },
+  { value: 'pt', label: 'Portugal' },
+  { value: 'jp', label: 'Japan' },
+  { value: 'de', label: 'Germany' },
+  { value: 'fr', label: 'France' },
+  { value: 'ca', label: 'Canada' },
+  { value: 'mx', label: 'Mexico' },
+  { value: 'es', label: 'Spain' },
+  { value: 'it', label: 'Italy' },
+]
+
+/** Simulates a remote search endpoint with latency. */
+export async function loadCountries(query: string): Promise<EnumOption[]> {
+  await new Promise((resolve) => setTimeout(resolve, 300))
+  const q = query.toLowerCase()
+  return COUNTRIES.filter((c) => c.label.toLowerCase().includes(q))
+}

--- a/apps/demo/src/examples/wizard-example.ts
+++ b/apps/demo/src/examples/wizard-example.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod'
+import type { WizardStep } from '@rogeroliveira84/react-dynamic-forms-ui'
+
+export const wizardSchema = z.object({
+  email: z.string().email().describe('Work email'),
+  password: z.string().min(8).describe('At least 8 characters'),
+  firstName: z.string().min(1),
+  lastName: z.string().min(1),
+  role: z.enum(['Engineer', 'Designer', 'Product Manager']),
+})
+
+export const wizardSteps: WizardStep[] = [
+  { title: 'Account', description: 'Your login details', fields: ['email', 'password'] },
+  { title: 'Profile', description: 'A bit about you', fields: ['firstName', 'lastName', 'role'] },
+]

--- a/docs/superpowers/specs/2026-06-05-rdf-power-features-design.md
+++ b/docs/superpowers/specs/2026-06-05-rdf-power-features-design.md
@@ -1,0 +1,216 @@
+# React Dynamic Forms — Power Features (Wizard · Combobox · i18n)
+
+**Status:** Draft v1
+**Date:** 2026-06-05
+**Author:** Roger Oliveira
+**Target audience:** contributors, future maintainers, AI coding agents
+
+---
+
+## 1. Goal
+
+Add the three remaining roadmap features to `@rogeroliveira84/react-dynamic-forms` in a single, focused release:
+
+1. **Multi-step wizard** — `DynamicForm.Wizard` for forms split into validated steps.
+2. **Combobox** — searchable single-select with optional **async** options.
+3. **i18n** — localized validation messages via one `locale` prop.
+
+**Non-negotiable design constraints** (these are acceptance criteria, not vibes):
+
+- **Small.** No heavy dependencies. Wizard adds 0 deps; i18n adds 0 deps; combobox adds exactly one small dep (`@radix-ui/react-popover`). Everything opt-in and tree-shakable.
+- **Fast.** No runtime cost for users who don't use a feature.
+- **Functional & obvious.** The common case needs zero config. APIs are named so an LLM asked to "build a React form" would reach for them by default.
+- **Backward compatible.** All three are purely additive. No breaking changes to existing schema inputs, `<DynamicForm>`, or `useDynamicForm`.
+
+## 2. Architecture context (extension points)
+
+The pipeline today:
+
+```
+schema (Zod | JSON Schema | legacy | InternalSchema)
+  → detectAndConvert → InternalSchema { fields: FieldSpec[] }
+  → useDynamicForm (core): builds zodSchema, RHF useForm + zodResolver
+  → <DynamicForm> (ui): FormProvider → fields.map(FieldResolver)
+  → FieldResolver: switch(kind) → <XField> using useFieldState + FieldWrapper
+```
+
+Each feature plugs into one of these seams:
+
+| Feature | Seam |
+|---|---|
+| Wizard | New `ui` component reusing `useDynamicForm` + `FieldResolver`; slices fields by step. **No core change.** |
+| Combobox | New `FieldKind` in core + adapter/zod-builder mappings + new `ui` field + `popover` primitive. |
+| i18n | New `core/i18n` module producing a Zod `errorMap`, wired into `zodResolver`; `locale`/`messages` props on `useDynamicForm`/`DynamicForm`. |
+
+A small shared piece of plumbing is introduced: **`RdfConfigContext`** (in `ui`) carrying render-time config that can't live in a static schema — currently just `asyncOptions`. `DynamicForm` and `DynamicForm.Wizard` provide it; fields consume it.
+
+## 3. Feature 1 — Multi-step Wizard
+
+### API
+
+```tsx
+<DynamicForm.Wizard
+  schema={schema}
+  steps={[
+    { title: 'Account', fields: ['email', 'password'] },
+    { title: 'Profile', description: 'Tell us about you', fields: ['name', 'age'] },
+  ]}
+  onSubmit={(data) => {}}
+  onStepChange={(index) => {}}   // optional
+  labels={{ next: 'Next', back: 'Back', submit: 'Finish' }}  // optional
+/>
+```
+
+```ts
+type WizardStep = { title?: string; description?: string; fields: string[] }
+type FormWizardProps<TValues> = {
+  schema: SchemaInput
+  steps: WizardStep[]
+  onSubmit: SubmitHandler<TValues>
+  defaultValues?: DefaultValues<TValues>
+  onStepChange?: (index: number) => void
+  labels?: { next?: string; back?: string; submit?: string }
+  // i18n + async options pass through to the underlying form:
+  locale?: RdfLocaleInput
+  messages?: RdfMessages
+  asyncOptions?: AsyncOptionsMap
+  className?: string
+}
+```
+
+`DynamicForm.Wizard` is a static property on `DynamicForm` (`DynamicForm.Wizard = FormWizard`). The named export `FormWizard` is also available. No default exports.
+
+### Behavior
+
+- One underlying form (`useDynamicForm`) shared across steps — values persist when navigating.
+- Renders only the current step's fields: filter `internalSchema.fields` by `name ∈ steps[current].fields`, render each through the existing `FieldResolver`.
+- **Next** calls `await form.trigger(currentStepFieldNames)`; advances only if valid. **Back** never validates.
+- Last step shows the submit button → `form.handleSubmit(onSubmit)` (validates the whole schema as a final guard).
+- Progress indicator: "Step N of M" + a dot/segment per step.
+- **DX guard:** in dev, `console.warn` if the union of all `steps[].fields` does not equal the schema's top-level field names (a field would otherwise silently block submit).
+
+### Out of scope
+
+Branching/conditional steps, per-step async submit, saving partial progress. (Conditional *fields* already exist via `showIf` and work inside steps.)
+
+## 4. Feature 2 — Combobox (with async options)
+
+### Core changes
+
+- Add `'combobox'` to `FieldKind`.
+- New spec:
+  ```ts
+  type ComboboxFieldSpec = BaseFieldSpec & {
+    kind: 'combobox'
+    options?: EnumOption[]   // static options; omitted when fed asynchronously
+  }
+  ```
+- `schema-to-zod`: `combobox` with `options` → `z.union(literals)`; without options (async) → `z.string()`. Honor `required`/optional like other kinds.
+- Adapters:
+  - **JSON Schema**: a string property with extension `x-rdf-combobox: true` → `combobox`; `enum` (if present) becomes static `options`.
+  - **InternalSchema passthrough**: already supported.
+  - **Zod**: no native marker. Zod users opt in at render time via `asyncOptions` (below) — `z.string()` is the natural schema for a free-form/remote value.
+
+### Render-time async upgrade (the killer-DX path)
+
+```tsx
+<DynamicForm
+  schema={z.object({ city: z.string() })}
+  asyncOptions={{ city: (query) => fetchCities(query) }}  // -> rendered as async combobox
+/>
+```
+
+```ts
+type AsyncOptionsMap = Record<string, (query: string) => Promise<EnumOption[]>>
+```
+
+- `DynamicForm`/`Wizard` accept `asyncOptions` and put it on `RdfConfigContext`.
+- `FieldResolver` upgrade rule: if `asyncOptions[field.name]` exists, render `ComboboxField` regardless of the field's declared `kind`. This lets a plain `z.string()` become a searchable async combobox with no schema gymnastics.
+
+### UI component (`ComboboxField`)
+
+- New primitive `primitives/popover.tsx` wrapping `@radix-ui/react-popover` (the single new dependency).
+- Composition: Popover trigger button (shows selected label or `placeholder`) + search `Input` + filtered option list.
+- **Static options:** filter client-side by the query.
+- **Async loader:** debounce input ~250ms, call `loadOptions(query)`, show a loading row, render results; cancel stale responses (ignore out-of-order results).
+- Selecting calls `rhf.onChange(option.value)` and stores the chosen `label` locally for display (async values may have no label in the schema).
+- **Keyboard & a11y:** ArrowUp/Down move the highlight, Enter selects, Escape closes; `role="listbox"`/`role="option"`, `aria-expanded`, `aria-activedescendant`, label wired through `FieldWrapper`.
+
+### Out of scope
+
+Multi-select combobox (`multi-combobox`), option grouping, create-on-the-fly. Multi-select is a clean follow-up but **not** in this release (YAGNI).
+
+## 5. Feature 3 — i18n (localized validation messages)
+
+### API
+
+```tsx
+<DynamicForm schema={schema} locale="pt-BR" />                  // localizes all messages
+<DynamicForm schema={schema} messages={{ too_small_string: ({ min }) => `Mín ${min}` }} />  // fine-grained override
+```
+
+`locale` and `messages` are also accepted by `useDynamicForm` and `DynamicForm.Wizard`.
+
+### Mechanism
+
+- Zod produces validation messages. We localize **without touching the schema** by passing a localized `errorMap` into `zodResolver(schema, { errorMap })`.
+- **Explicit schema messages win.** A message set in the schema (`z.string().email({ message: '...' })`) takes priority over the error map — by Zod's own precedence. So localization never clobbers intentional custom messages.
+
+### Module shape (`packages/core/src/i18n/`)
+
+- `messages.ts` — `type RdfMessages` = partial map of curated keys → `string | (params) => string`. Curated keys (the ones that actually matter for forms): `required`, `invalid_type`, `too_small_string`, `too_big_string`, `too_small_number`, `too_big_number`, `invalid_string_email`, `invalid_string_url`, `invalid_string_regex`, `invalid_enum_value`, `invalid_date`.
+- `locales/en.ts`, `locales/pt-BR.ts`, `locales/es.ts` — each a full `RdfMessages`. Tiny objects.
+- `error-map.ts` — `createErrorMap(messages: RdfMessages): ZodErrorMap` mapping each Zod issue to the localized string, falling back to `ctx.defaultError`.
+- `resolve-messages.ts` — `resolveMessages(locale?, overrides?)` merges the chosen pack over `en`, then `overrides` on top.
+- `type RdfLocaleInput = 'en' | 'pt-BR' | 'es' | RdfMessages` — accept a known locale string **or** a custom message object.
+
+### Wiring
+
+`useDynamicForm` builds the `errorMap` with `useMemo(locale, messages)` and passes `{ errorMap }` to `zodResolver`. Default (no `locale`) = English, identical to today's behavior (no regression).
+
+### Out of scope
+
+Translating field labels/descriptions (that's user content), RTL layout, locales beyond `en`/`pt-BR`/`es` (community can add packs later), async validation messages.
+
+## 6. Shared plumbing — `RdfConfigContext`
+
+A minimal React context in `ui`:
+
+```ts
+type RdfConfig = { asyncOptions?: AsyncOptionsMap }
+```
+
+`DynamicForm` and `DynamicForm.Wizard` wrap their fields in `<RdfConfigContext.Provider>`. `FieldResolver`/`ComboboxField` read it. Kept intentionally tiny — `locale`/`messages` do **not** go here (they're consumed in core at resolver-build time, not by fields).
+
+## 7. Testing strategy (TDD, co-located)
+
+- **core / i18n:** error map changes message by locale; override beats locale pack; explicit schema message beats both; unknown locale falls back to `en`.
+- **core / combobox:** JSON Schema `x-rdf-combobox` → `combobox` kind; `schema-to-zod` builds union (static) and string (async); optional vs required.
+- **ui / wizard:** renders only step 1; **Next blocked** while a step field is invalid; advances when valid; **Back** preserves values without validating; submit fires on the last step; dev warning when steps don't cover all fields.
+- **ui / combobox:** opens on click; filters static options; async loader called (debounced) and results selectable; keyboard navigation (arrows/enter/escape); stale async response ignored.
+- **ui / i18n integration:** `locale="pt-BR"` renders a Portuguese error in a real form submit.
+
+Coverage: keep `core` ≥ 85% (CI gate). New `ui` components: happy path + error/empty + a11y of the combobox listbox.
+
+## 8. Bundle & release
+
+- **Bundle deltas:** wizard ≈ 0; i18n ≈ tiny (three small locale objects + a mapper); combobox = `@radix-ui/react-popover` + the field/primitive. All tree-shakable; unused features cost nothing.
+- **Changeset:** one `minor` covering `@rogeroliveira84/react-dynamic-forms` + `@rogeroliveira84/react-dynamic-forms-ui` (they are `linked`).
+- **Demo:** add one example per feature to `apps/demo` (wizard form, async-city combobox, `pt-BR` validation) so each is exercised end-to-end.
+
+## 9. Implementation order (parallelizable)
+
+The three features are independent and will be implemented in parallel, then integrated in a single PR:
+
+- **Track A — i18n** (core only): `i18n/` module + `useDynamicForm` wiring + tests.
+- **Track B — Combobox** (core + ui): `FieldKind`/spec/zod-builder/adapter + `popover` primitive + `ComboboxField` + `RdfConfigContext` + `asyncOptions` on `DynamicForm` + tests.
+- **Track C — Wizard** (ui only): `FormWizard` + `DynamicForm.Wizard` + tests.
+
+Integration touch-points to reconcile last: `DynamicForm` props gain `locale`/`messages` (A) and `asyncOptions` (B); `DynamicForm.Wizard` (C) forwards all three. `RdfConfigContext` (B) is provided by both `DynamicForm` and the wizard.
+
+## 10. Out of scope (firmly)
+
+- Multi-select combobox, option grouping, create-new-option.
+- Branching wizard steps, per-step async submit, persisted progress.
+- Label/description translation, RTL, extra locales, async validation.
+- Any AI / schema-generation / hosting / deploy work — explicitly excluded.

--- a/packages/ai/src/emit-zod.ts
+++ b/packages/ai/src/emit-zod.ts
@@ -57,6 +57,15 @@ function emitField(field: FieldSpec): string {
       expr = `z.array(${inner})`
       break
     }
+    case 'combobox': {
+      if (field.options && field.options.length > 0) {
+        const parts = field.options.map((o) => `z.literal(${quote(o.value)})`).join(', ')
+        expr = field.options.length >= 2 ? `z.union([${parts}])` : parts
+      } else {
+        expr = 'z.string()'
+      }
+      break
+    }
     case 'array':
       expr = `z.array(${emitField(field.item)})`
       break

--- a/packages/ai/src/internal-to-json-schema.ts
+++ b/packages/ai/src/internal-to-json-schema.ts
@@ -42,6 +42,15 @@ function fieldToJsonSchema(field: FieldSpec): JsonSchema {
       return { ...base, type: 'string', format: 'time' }
     case 'enum':
       return { ...base, type: 'string', enum: field.options.map((o) => o.value) }
+    case 'combobox': {
+      const out: JsonSchema & { 'x-rdf-combobox'?: boolean } = {
+        ...base,
+        type: 'string',
+        'x-rdf-combobox': true,
+      }
+      if (field.options) out.enum = field.options.map((o) => o.value)
+      return out
+    }
     case 'multi-enum':
       return {
         ...base,

--- a/packages/core/src/adapters/json-schema.combobox.test.ts
+++ b/packages/core/src/adapters/json-schema.combobox.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { jsonSchemaToInternalSchema } from './json-schema'
+
+describe('json-schema combobox', () => {
+  it('maps an x-rdf-combobox string with enum to combobox kind + options', () => {
+    const res = jsonSchemaToInternalSchema({
+      type: 'object',
+      properties: {
+        city: { type: 'string', enum: ['NY', 'LA'], 'x-rdf-combobox': true },
+      },
+    })
+    expect(res.fields[0]).toMatchObject({
+      kind: 'combobox',
+      name: 'city',
+      options: [
+        { value: 'NY', label: 'NY' },
+        { value: 'LA', label: 'LA' },
+      ],
+    })
+  })
+
+  it('maps an x-rdf-combobox string without enum to combobox without options', () => {
+    const res = jsonSchemaToInternalSchema({
+      type: 'object',
+      properties: { city: { type: 'string', 'x-rdf-combobox': true } },
+    })
+    expect(res.fields[0]).toMatchObject({ kind: 'combobox', name: 'city' })
+    expect((res.fields[0] as { options?: unknown }).options).toBeUndefined()
+  })
+})

--- a/packages/core/src/adapters/json-schema.ts
+++ b/packages/core/src/adapters/json-schema.ts
@@ -22,6 +22,7 @@ export type JsonSchema = {
   'x-rdf-show-if'?: ShowIfRule
   'x-rdf-max-size'?: number
   'x-rdf-multiple'?: boolean
+  'x-rdf-combobox'?: boolean
 }
 
 function jsonFieldFromSchema(name: string, schema: JsonSchema, required: boolean): FieldSpec {
@@ -33,6 +34,12 @@ function jsonFieldFromSchema(name: string, schema: JsonSchema, required: boolean
     ...(schema.default !== undefined ? { defaultValue: schema.default } : {}),
   })
   if (schema['x-rdf-show-if']) base.showIf = schema['x-rdf-show-if']
+
+  if (schema['x-rdf-combobox']) {
+    const field: FieldSpec = { ...base, kind: 'combobox' }
+    if (schema.enum) field.options = schema.enum.map((v) => ({ value: v, label: String(v) }))
+    return field
+  }
 
   if (schema.enum) {
     const options: EnumOption[] = schema.enum.map((v) => ({ value: v, label: String(v) }))

--- a/packages/core/src/i18n/error-map.ts
+++ b/packages/core/src/i18n/error-map.ts
@@ -1,0 +1,47 @@
+import { ZodIssueCode, type ZodErrorMap } from 'zod'
+import type { RdfMessageKey, RdfMessageParams, RdfMessages } from './messages'
+
+/**
+ * Build a Zod error map from a resolved message set. Returned messages are used
+ * for the issues we localize; anything else falls back to Zod's `defaultError`.
+ * Messages set explicitly on a schema (e.g. `z.string().email({ message })`)
+ * still win — Zod consults them before this map.
+ */
+export function createErrorMap(messages: RdfMessages): ZodErrorMap {
+  const pick = (key: RdfMessageKey, params?: RdfMessageParams): string | undefined => {
+    const value = messages[key]
+    if (value === undefined) return undefined
+    return typeof value === 'function' ? value(params ?? {}) : value
+  }
+
+  return (issue, ctx) => {
+    let message: string | undefined
+
+    switch (issue.code) {
+      case ZodIssueCode.invalid_type:
+        message = issue.received === 'undefined' ? pick('required') : pick('invalid_type')
+        break
+      case ZodIssueCode.too_small:
+        if (issue.type === 'string') message = pick('too_small_string', { minimum: issue.minimum })
+        else if (issue.type === 'number') message = pick('too_small_number', { minimum: issue.minimum })
+        break
+      case ZodIssueCode.too_big:
+        if (issue.type === 'string') message = pick('too_big_string', { maximum: issue.maximum })
+        else if (issue.type === 'number') message = pick('too_big_number', { maximum: issue.maximum })
+        break
+      case ZodIssueCode.invalid_string:
+        if (issue.validation === 'email') message = pick('invalid_string_email')
+        else if (issue.validation === 'url') message = pick('invalid_string_url')
+        else if (issue.validation === 'regex') message = pick('invalid_string_regex')
+        break
+      case ZodIssueCode.invalid_enum_value:
+        message = pick('invalid_enum_value', { options: issue.options })
+        break
+      case ZodIssueCode.invalid_date:
+        message = pick('invalid_date')
+        break
+    }
+
+    return { message: message ?? ctx.defaultError }
+  }
+}

--- a/packages/core/src/i18n/i18n.test.ts
+++ b/packages/core/src/i18n/i18n.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { z, type ZodErrorMap } from 'zod'
+import { createErrorMap, resolveMessages } from './index'
+
+function firstError(schema: z.ZodTypeAny, value: unknown, errorMap: ZodErrorMap): string | undefined {
+  const res = schema.safeParse(value, { errorMap })
+  return res.success ? undefined : res.error.issues[0]?.message
+}
+
+describe('i18n error map', () => {
+  it('localizes the email error in pt-BR', () => {
+    const map = createErrorMap(resolveMessages('pt-BR'))
+    expect(firstError(z.string().email(), 'nope', map)).toBe('Informe um e-mail válido')
+  })
+
+  it('localizes the email error in es', () => {
+    const map = createErrorMap(resolveMessages('es'))
+    expect(firstError(z.string().email(), 'nope', map)).toBe('Introduce un correo válido')
+  })
+
+  it('falls back to English for an unknown locale', () => {
+    const map = createErrorMap(resolveMessages('xx' as never))
+    expect(firstError(z.string().email(), 'nope', map)).toBe('Enter a valid email')
+  })
+
+  it('lets an override beat the locale pack', () => {
+    const map = createErrorMap(resolveMessages('pt-BR', { invalid_string_email: 'E-mail ruim' }))
+    expect(firstError(z.string().email(), 'nope', map)).toBe('E-mail ruim')
+  })
+
+  it('lets an explicit schema message win over the error map', () => {
+    const map = createErrorMap(resolveMessages('pt-BR'))
+    expect(firstError(z.string().email({ message: 'MINE' }), 'nope', map)).toBe('MINE')
+  })
+
+  it('localizes a missing required field in pt-BR', () => {
+    const map = createErrorMap(resolveMessages('pt-BR'))
+    expect(firstError(z.object({ name: z.string() }), {}, map)).toBe('Obrigatório')
+  })
+
+  it('interpolates the minimum into a too_small string message', () => {
+    const map = createErrorMap(resolveMessages('pt-BR'))
+    expect(firstError(z.string().min(5), 'ab', map)).toBe('Mínimo de 5 caracteres')
+  })
+
+  it('accepts a custom message object as the locale', () => {
+    const map = createErrorMap(resolveMessages({ invalid_string_email: 'Custom' }))
+    expect(firstError(z.string().email(), 'nope', map)).toBe('Custom')
+  })
+})

--- a/packages/core/src/i18n/index.ts
+++ b/packages/core/src/i18n/index.ts
@@ -1,0 +1,6 @@
+export { createErrorMap } from './error-map'
+export { resolveMessages, type RdfLocale, type RdfLocaleInput } from './resolve-messages'
+export type { RdfMessages, RdfMessageKey, RdfMessageValue, RdfMessageParams } from './messages'
+export { en } from './locales/en'
+export { ptBR } from './locales/pt-BR'
+export { es } from './locales/es'

--- a/packages/core/src/i18n/locales/en.ts
+++ b/packages/core/src/i18n/locales/en.ts
@@ -1,0 +1,17 @@
+import type { RdfMessages } from '../messages'
+
+export const en: RdfMessages = {
+  required: 'Required',
+  invalid_type: 'Invalid value',
+  too_small_string: ({ minimum }) =>
+    `Must be at least ${minimum} character${Number(minimum) === 1 ? '' : 's'}`,
+  too_big_string: ({ maximum }) =>
+    `Must be at most ${maximum} character${Number(maximum) === 1 ? '' : 's'}`,
+  too_small_number: ({ minimum }) => `Must be ≥ ${minimum}`,
+  too_big_number: ({ maximum }) => `Must be ≤ ${maximum}`,
+  invalid_string_email: 'Enter a valid email',
+  invalid_string_url: 'Enter a valid URL',
+  invalid_string_regex: 'Invalid format',
+  invalid_enum_value: 'Select a valid option',
+  invalid_date: 'Enter a valid date',
+}

--- a/packages/core/src/i18n/locales/es.ts
+++ b/packages/core/src/i18n/locales/es.ts
@@ -1,0 +1,17 @@
+import type { RdfMessages } from '../messages'
+
+export const es: RdfMessages = {
+  required: 'Obligatorio',
+  invalid_type: 'Valor inválido',
+  too_small_string: ({ minimum }) =>
+    `Mínimo de ${minimum} carácter${Number(minimum) === 1 ? '' : 'es'}`,
+  too_big_string: ({ maximum }) =>
+    `Máximo de ${maximum} carácter${Number(maximum) === 1 ? '' : 'es'}`,
+  too_small_number: ({ minimum }) => `Debe ser ≥ ${minimum}`,
+  too_big_number: ({ maximum }) => `Debe ser ≤ ${maximum}`,
+  invalid_string_email: 'Introduce un correo válido',
+  invalid_string_url: 'Introduce una URL válida',
+  invalid_string_regex: 'Formato inválido',
+  invalid_enum_value: 'Selecciona una opción válida',
+  invalid_date: 'Introduce una fecha válida',
+}

--- a/packages/core/src/i18n/locales/pt-BR.ts
+++ b/packages/core/src/i18n/locales/pt-BR.ts
@@ -1,0 +1,17 @@
+import type { RdfMessages } from '../messages'
+
+export const ptBR: RdfMessages = {
+  required: 'Obrigatório',
+  invalid_type: 'Valor inválido',
+  too_small_string: ({ minimum }) =>
+    `Mínimo de ${minimum} caractere${Number(minimum) === 1 ? '' : 's'}`,
+  too_big_string: ({ maximum }) =>
+    `Máximo de ${maximum} caractere${Number(maximum) === 1 ? '' : 's'}`,
+  too_small_number: ({ minimum }) => `Deve ser ≥ ${minimum}`,
+  too_big_number: ({ maximum }) => `Deve ser ≤ ${maximum}`,
+  invalid_string_email: 'Informe um e-mail válido',
+  invalid_string_url: 'Informe uma URL válida',
+  invalid_string_regex: 'Formato inválido',
+  invalid_enum_value: 'Selecione uma opção válida',
+  invalid_date: 'Informe uma data válida',
+}

--- a/packages/core/src/i18n/messages.ts
+++ b/packages/core/src/i18n/messages.ts
@@ -1,0 +1,22 @@
+export type RdfMessageKey =
+  | 'required'
+  | 'invalid_type'
+  | 'too_small_string'
+  | 'too_big_string'
+  | 'too_small_number'
+  | 'too_big_number'
+  | 'invalid_string_email'
+  | 'invalid_string_url'
+  | 'invalid_string_regex'
+  | 'invalid_enum_value'
+  | 'invalid_date'
+
+export type RdfMessageParams = {
+  minimum?: number | bigint
+  maximum?: number | bigint
+  options?: (string | number)[]
+}
+
+export type RdfMessageValue = string | ((params: RdfMessageParams) => string)
+
+export type RdfMessages = Partial<Record<RdfMessageKey, RdfMessageValue>>

--- a/packages/core/src/i18n/resolve-messages.ts
+++ b/packages/core/src/i18n/resolve-messages.ts
@@ -1,0 +1,25 @@
+import type { RdfMessages } from './messages'
+import { en } from './locales/en'
+import { ptBR } from './locales/pt-BR'
+import { es } from './locales/es'
+
+export type RdfLocale = 'en' | 'pt-BR' | 'es'
+
+/** A built-in locale name, or a custom message object. */
+export type RdfLocaleInput = RdfLocale | RdfMessages
+
+const PACKS: Record<RdfLocale, RdfMessages> = { en, 'pt-BR': ptBR, es }
+
+/**
+ * Merge the English base, the chosen locale (built-in name or custom object),
+ * then per-key overrides on top. Unknown locale names fall back to English.
+ */
+export function resolveMessages(locale?: RdfLocaleInput, overrides?: RdfMessages): RdfMessages {
+  let pack: RdfMessages = en
+  if (typeof locale === 'string') {
+    pack = PACKS[locale as RdfLocale] ?? en
+  } else if (locale) {
+    pack = locale
+  }
+  return { ...en, ...pack, ...(overrides ?? {}) }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,6 +12,16 @@ export type { LegacyConfig, LegacyField, LegacyOption } from './adapters/legacy'
 
 export { internalToZod } from './schema-to-zod'
 
+export { createErrorMap, resolveMessages, en, ptBR, es } from './i18n'
+export type {
+  RdfLocale,
+  RdfLocaleInput,
+  RdfMessages,
+  RdfMessageKey,
+  RdfMessageValue,
+  RdfMessageParams,
+} from './i18n'
+
 export type {
   InternalSchema,
   FieldSpec,
@@ -24,6 +34,7 @@ export type {
   BooleanFieldSpec,
   DateFieldSpec,
   EnumFieldSpec,
+  ComboboxFieldSpec,
   ObjectFieldSpec,
   ArrayFieldSpec,
   FileFieldSpec,

--- a/packages/core/src/internal-schema.ts
+++ b/packages/core/src/internal-schema.ts
@@ -12,6 +12,7 @@ export type FieldKind =
   | 'time'
   | 'enum'
   | 'multi-enum'
+  | 'combobox'
   | 'object'
   | 'array'
   | 'file'
@@ -62,6 +63,12 @@ export type EnumFieldSpec = BaseFieldSpec & {
   options: EnumOption[]
 }
 
+export type ComboboxFieldSpec = BaseFieldSpec & {
+  kind: 'combobox'
+  /** Static options. Omitted when options are supplied asynchronously at render time. */
+  options?: EnumOption[]
+}
+
 export type ObjectFieldSpec = BaseFieldSpec & {
   kind: 'object'
   fields: FieldSpec[]
@@ -87,6 +94,7 @@ export type FieldSpec =
   | BooleanFieldSpec
   | DateFieldSpec
   | EnumFieldSpec
+  | ComboboxFieldSpec
   | ObjectFieldSpec
   | ArrayFieldSpec
   | FileFieldSpec

--- a/packages/core/src/schema-to-zod.combobox.test.ts
+++ b/packages/core/src/schema-to-zod.combobox.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { internalToZod } from './schema-to-zod'
+import type { InternalSchema } from './internal-schema'
+
+describe('schema-to-zod combobox', () => {
+  it('builds a union validator from static options', () => {
+    const is: InternalSchema = {
+      fields: [
+        {
+          kind: 'combobox',
+          name: 'c',
+          required: true,
+          options: [
+            { value: 'a', label: 'A' },
+            { value: 'b', label: 'B' },
+          ],
+        },
+      ],
+    }
+    const zod = internalToZod(is)
+    expect(zod.safeParse({ c: 'a' }).success).toBe(true)
+    expect(zod.safeParse({ c: 'z' }).success).toBe(false)
+  })
+
+  it('falls back to a string validator when options are absent (async)', () => {
+    const is: InternalSchema = { fields: [{ kind: 'combobox', name: 'c', required: true }] }
+    const zod = internalToZod(is)
+    expect(zod.safeParse({ c: 'anything' }).success).toBe(true)
+    expect(zod.safeParse({ c: 123 }).success).toBe(false)
+  })
+
+  it('respects optional', () => {
+    const is: InternalSchema = { fields: [{ kind: 'combobox', name: 'c', required: false }] }
+    const zod = internalToZod(is)
+    expect(zod.safeParse({}).success).toBe(true)
+  })
+})

--- a/packages/core/src/schema-to-zod.ts
+++ b/packages/core/src/schema-to-zod.ts
@@ -55,6 +55,14 @@ function fieldToZod(f: FieldSpec): ZodTypeAny {
       s = z.array(enumUnion(values))
       break
     }
+    case 'combobox': {
+      if (f.options && f.options.length > 0) {
+        s = enumUnion(f.options.map((o) => z.literal(o.value)))
+      } else {
+        s = z.string()
+      }
+      break
+    }
     case 'array':
       s = z.array(fieldToZod(f.item))
       break

--- a/packages/core/src/use-dynamic-form.i18n.test.tsx
+++ b/packages/core/src/use-dynamic-form.i18n.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { z } from 'zod'
+import { useDynamicForm } from './use-dynamic-form'
+
+async function emailError(options: Parameters<typeof useDynamicForm>[0]): Promise<string | undefined> {
+  const { result } = renderHook(() => {
+    const r = useDynamicForm(options)
+    // Subscribe to errors during render so RHF keeps formState.errors live.
+    void r.form.formState.errors
+    return r
+  })
+  await act(async () => {
+    result.current.form.setValue('email', 'nope')
+    await result.current.form.handleSubmit(() => {})()
+  })
+  return result.current.form.formState.errors.email?.message as string | undefined
+}
+
+describe('useDynamicForm i18n', () => {
+  const schema = z.object({ email: z.string().email() })
+
+  it('localizes validation messages when a locale is set', async () => {
+    expect(await emailError({ schema, locale: 'pt-BR' })).toBe('Informe um e-mail válido')
+  })
+
+  it('applies per-key overrides on top of the locale', async () => {
+    expect(
+      await emailError({ schema, locale: 'pt-BR', messages: { invalid_string_email: 'E-mail ruim' } }),
+    ).toBe('E-mail ruim')
+  })
+
+  it('keeps the default English behavior when no locale is set', async () => {
+    expect(await emailError({ schema })).toMatch(/invalid email/i)
+  })
+})

--- a/packages/core/src/use-dynamic-form.ts
+++ b/packages/core/src/use-dynamic-form.ts
@@ -12,11 +12,16 @@ import { detectAndConvert, type SchemaInput } from './adapters/detect'
 import { isZodLike } from './adapters/is-zod'
 import { internalToZod } from './schema-to-zod'
 import type { InternalSchema } from './internal-schema'
+import { createErrorMap, resolveMessages, type RdfLocaleInput, type RdfMessages } from './i18n'
 
 export type UseDynamicFormOptions<TValues extends FieldValues = FieldValues> = {
   schema: SchemaInput
   defaultValues?: DefaultValues<TValues>
   mode?: UseFormProps<TValues>['mode']
+  /** Built-in locale name ('en' | 'pt-BR' | 'es') or a custom message object. */
+  locale?: RdfLocaleInput
+  /** Per-key overrides applied on top of the locale. */
+  messages?: RdfMessages
 }
 
 export type UseDynamicFormReturn<TValues extends FieldValues = FieldValues> = {
@@ -36,7 +41,13 @@ export function useDynamicForm<TValues extends FieldValues = FieldValues>(
         : (internalToZod(internalSchema) as ZodType<unknown>),
     [options.schema, internalSchema],
   )
-  const resolver = useMemo(() => zodResolver(zodSchema), [zodSchema])
+  const resolver = useMemo(() => {
+    if (options.locale === undefined && options.messages === undefined) {
+      return zodResolver(zodSchema)
+    }
+    const errorMap = createErrorMap(resolveMessages(options.locale, options.messages))
+    return zodResolver(zodSchema, { errorMap })
+  }, [zodSchema, options.locale, options.messages])
 
   const form = useForm<TValues>({
     resolver,

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -52,6 +52,7 @@
   "dependencies": {
     "@radix-ui/react-checkbox": "^1.1.2",
     "@radix-ui/react-label": "^2.1.0",
+    "@radix-ui/react-popover": "^1.1.2",
     "@radix-ui/react-select": "^2.1.2",
     "@radix-ui/react-slider": "^1.2.1",
     "@radix-ui/react-slot": "^1.1.0",

--- a/packages/ui/src/combobox-field.test.tsx
+++ b/packages/ui/src/combobox-field.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { z } from 'zod'
+import { DynamicForm } from './dynamic-form'
+
+describe('combobox', () => {
+  const staticSchema = {
+    type: 'object' as const,
+    properties: {
+      fruit: {
+        type: 'string' as const,
+        enum: ['Apple', 'Banana', 'Cherry'],
+        'x-rdf-combobox': true,
+      },
+    },
+    required: ['fruit'],
+  }
+
+  it('opens, filters static options, and selects one', async () => {
+    const onSubmit = vi.fn()
+    render(<DynamicForm schema={staticSchema} onSubmit={onSubmit} />)
+    await userEvent.click(screen.getByRole('combobox'))
+    await userEvent.type(screen.getByPlaceholderText(/search/i), 'ban')
+    await userEvent.click(screen.getByText('Banana'))
+    await userEvent.click(screen.getByRole('button', { name: /submit/i }))
+    expect(onSubmit).toHaveBeenCalled()
+    expect(onSubmit.mock.calls[0]?.[0]).toMatchObject({ fruit: 'Banana' })
+  })
+
+  it('loads async options via asyncOptions and selects one', async () => {
+    const onSubmit = vi.fn()
+    const loadOptions = vi.fn(async (q: string) =>
+      [
+        { value: 'br', label: 'Brazil' },
+        { value: 'us', label: 'United States' },
+      ].filter((o) => o.label.toLowerCase().includes(q.toLowerCase())),
+    )
+    render(
+      <DynamicForm
+        schema={z.object({ country: z.string() })}
+        asyncOptions={{ country: loadOptions }}
+        onSubmit={onSubmit}
+      />,
+    )
+    await userEvent.click(screen.getByRole('combobox'))
+    await userEvent.type(screen.getByPlaceholderText(/search/i), 'bra')
+    await userEvent.click(await screen.findByText('Brazil'))
+    await userEvent.click(screen.getByRole('button', { name: /submit/i }))
+    expect(loadOptions).toHaveBeenCalled()
+    expect(onSubmit.mock.calls[0]?.[0]).toMatchObject({ country: 'br' })
+  })
+})

--- a/packages/ui/src/dynamic-form.i18n.test.tsx
+++ b/packages/ui/src/dynamic-form.i18n.test.tsx
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { z } from 'zod'
+import { DynamicForm } from './dynamic-form'
+
+describe('<DynamicForm> i18n', () => {
+  it('shows a localized (pt-BR) validation message on submit', async () => {
+    render(
+      <DynamicForm schema={z.object({ email: z.string().email() })} locale="pt-BR" onSubmit={() => {}} />,
+    )
+    await userEvent.type(screen.getByLabelText(/email/i), 'nope')
+    await userEvent.click(screen.getByRole('button', { name: /submit/i }))
+    expect(await screen.findByText('Informe um e-mail válido')).toBeInTheDocument()
+  })
+
+  it('keeps English when no locale is given', async () => {
+    render(<DynamicForm schema={z.object({ email: z.string().email() })} onSubmit={() => {}} />)
+    await userEvent.type(screen.getByLabelText(/email/i), 'nope')
+    await userEvent.click(screen.getByRole('button', { name: /submit/i }))
+    expect(await screen.findByText(/invalid email/i)).toBeInTheDocument()
+  })
+})

--- a/packages/ui/src/dynamic-form.tsx
+++ b/packages/ui/src/dynamic-form.tsx
@@ -1,7 +1,15 @@
 import { FormProvider, type FieldValues, type SubmitHandler, type DefaultValues } from 'react-hook-form'
-import { useDynamicForm, type SchemaInput } from '@rogeroliveira84/react-dynamic-forms'
+import {
+  useDynamicForm,
+  type SchemaInput,
+  type RdfLocaleInput,
+  type RdfMessages,
+} from '@rogeroliveira84/react-dynamic-forms'
+import type { ReactElement } from 'react'
 import { Button } from './primitives/button'
 import { FieldResolver } from './fields/field-resolver'
+import { RdfConfigProvider, type AsyncOptionsMap } from './fields/rdf-config'
+import { FormWizard } from './form-wizard'
 import { cn } from './utils/cn'
 
 export type DynamicFormProps<TValues extends FieldValues = FieldValues> = {
@@ -13,13 +21,19 @@ export type DynamicFormProps<TValues extends FieldValues = FieldValues> = {
   title?: string
   description?: string
   showSubmit?: boolean
+  /** Built-in locale name ('en' | 'pt-BR' | 'es') or a custom message object for validation messages. */
+  locale?: RdfLocaleInput
+  /** Per-key overrides applied on top of the locale. */
+  messages?: RdfMessages
+  /** Async option loaders keyed by field name. A field with a loader renders as a searchable combobox. */
+  asyncOptions?: AsyncOptionsMap
   /** @deprecated Renamed to `schema`. Kept working with a warning through v1; removed in v2. */
   config?: SchemaInput
 }
 
-export function DynamicForm<TValues extends FieldValues = FieldValues>(
+function DynamicFormComponent<TValues extends FieldValues = FieldValues>(
   props: DynamicFormProps<TValues>,
-) {
+): ReactElement | null {
   const schemaInput = props.schema ?? props.config
   if (!schemaInput) {
     console.error('[react-dynamic-forms] <DynamicForm> requires a `schema` prop; nothing rendered.')
@@ -34,29 +48,41 @@ export function DynamicForm<TValues extends FieldValues = FieldValues>(
   const { form, internalSchema } = useDynamicForm<TValues>({
     schema: schemaInput,
     defaultValues: props.defaultValues,
+    locale: props.locale,
+    messages: props.messages,
   })
 
   const title = props.title ?? internalSchema.title
   const description = props.description ?? internalSchema.description
 
   return (
-    <FormProvider {...form}>
-      <form
-        onSubmit={form.handleSubmit(props.onSubmit)}
-        className={cn('flex flex-col gap-4', props.className)}
-        noValidate
-      >
-        {title && <h2 className="text-lg font-semibold">{title}</h2>}
-        {description && <p className="text-sm text-muted-foreground">{description}</p>}
-        {internalSchema.fields.map((f) => (
-          <FieldResolver key={f.name} field={f} />
-        ))}
-        {props.showSubmit !== false && (
-          <div className="mt-2">
-            <Button type="submit">{props.submitLabel ?? 'Submit'}</Button>
-          </div>
-        )}
-      </form>
-    </FormProvider>
+    <RdfConfigProvider value={{ asyncOptions: props.asyncOptions }}>
+      <FormProvider {...form}>
+        <form
+          onSubmit={form.handleSubmit(props.onSubmit)}
+          className={cn('flex flex-col gap-4', props.className)}
+          noValidate
+        >
+          {title && <h2 className="text-lg font-semibold">{title}</h2>}
+          {description && <p className="text-sm text-muted-foreground">{description}</p>}
+          {internalSchema.fields.map((f) => (
+            <FieldResolver key={f.name} field={f} />
+          ))}
+          {props.showSubmit !== false && (
+            <div className="mt-2">
+              <Button type="submit">{props.submitLabel ?? 'Submit'}</Button>
+            </div>
+          )}
+        </form>
+      </FormProvider>
+    </RdfConfigProvider>
   )
 }
+
+type DynamicFormType = {
+  <TValues extends FieldValues = FieldValues>(props: DynamicFormProps<TValues>): ReactElement | null
+  Wizard: typeof FormWizard
+}
+
+/** Renders a fully-validated form from a schema. `DynamicForm.Wizard` renders the multi-step variant. */
+export const DynamicForm: DynamicFormType = Object.assign(DynamicFormComponent, { Wizard: FormWizard })

--- a/packages/ui/src/fields/combobox-field.tsx
+++ b/packages/ui/src/fields/combobox-field.tsx
@@ -1,0 +1,172 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { Controller } from 'react-hook-form'
+import type { ComboboxFieldSpec, EnumOption } from '@rogeroliveira84/react-dynamic-forms'
+import { Popover, PopoverContent, PopoverTrigger } from '../primitives/popover'
+import { Input } from '../primitives/input'
+import { FieldWrapper } from './field-wrapper'
+import { useFieldState } from './use-field-state'
+import { useRdfConfig } from './rdf-config'
+import { cn } from '../utils/cn'
+
+type Loader = (query: string) => Promise<EnumOption[]>
+
+type ControlProps = {
+  id: string
+  placeholder: string
+  staticOptions: EnumOption[] | undefined
+  loader: Loader | undefined
+  value: unknown
+  onChange: (value: unknown) => void
+  onBlur: () => void
+}
+
+function ComboboxControl({ id, placeholder, staticOptions, loader, value, onChange, onBlur }: ControlProps) {
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const [asyncItems, setAsyncItems] = useState<EnumOption[]>([])
+  const [loading, setLoading] = useState(false)
+  const [labelCache, setLabelCache] = useState<Record<string, string>>({})
+  const [active, setActive] = useState(0)
+  const requestId = useRef(0)
+
+  useEffect(() => {
+    if (!loader || !open) return
+    const id = ++requestId.current
+    setLoading(true)
+    const timer = setTimeout(() => {
+      loader(query)
+        .then((res) => {
+          if (id !== requestId.current) return
+          setAsyncItems(res)
+          setLabelCache((cache) => {
+            const next = { ...cache }
+            for (const o of res) next[String(o.value)] = o.label
+            return next
+          })
+        })
+        .finally(() => {
+          if (id === requestId.current) setLoading(false)
+        })
+    }, 200)
+    return () => clearTimeout(timer)
+  }, [query, loader, open])
+
+  const items: EnumOption[] = useMemo(() => {
+    if (loader) return asyncItems
+    const all = staticOptions ?? []
+    if (!query) return all
+    return all.filter((o) => o.label.toLowerCase().includes(query.toLowerCase()))
+  }, [loader, asyncItems, staticOptions, query])
+
+  const selectedLabel =
+    value === undefined || value === null || value === ''
+      ? undefined
+      : (staticOptions?.find((o) => o.value === value)?.label ?? labelCache[String(value)] ?? String(value))
+
+  const choose = (opt: EnumOption) => {
+    onChange(opt.value)
+    setLabelCache((cache) => ({ ...cache, [String(opt.value)]: opt.label }))
+    setOpen(false)
+    setQuery('')
+    onBlur()
+  }
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next)
+        if (!next) onBlur()
+      }}
+    >
+      <PopoverTrigger
+        id={id}
+        type="button"
+        role="combobox"
+        aria-expanded={open}
+        className={cn(
+          'flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+          !selectedLabel && 'text-muted-foreground',
+        )}
+      >
+        <span className="truncate">{selectedLabel ?? placeholder}</span>
+      </PopoverTrigger>
+      <PopoverContent>
+        <Input
+          autoFocus
+          placeholder="Search…"
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value)
+            setActive(0)
+          }}
+          onKeyDown={(e) => {
+            if (e.key === 'ArrowDown') {
+              e.preventDefault()
+              setActive((a) => Math.min(a + 1, items.length - 1))
+            } else if (e.key === 'ArrowUp') {
+              e.preventDefault()
+              setActive((a) => Math.max(a - 1, 0))
+            } else if (e.key === 'Enter') {
+              e.preventDefault()
+              const opt = items[active]
+              if (opt) choose(opt)
+            } else if (e.key === 'Escape') {
+              setOpen(false)
+            }
+          }}
+          className="mb-1 h-9"
+        />
+        <ul role="listbox" className="max-h-56 overflow-auto">
+          {loading && <li className="px-2 py-1.5 text-sm text-muted-foreground">Loading…</li>}
+          {!loading && items.length === 0 && (
+            <li className="px-2 py-1.5 text-sm text-muted-foreground">No results</li>
+          )}
+          {items.map((opt, i) => (
+            <li
+              key={String(opt.value)}
+              role="option"
+              aria-selected={opt.value === value}
+              className={cn(
+                'cursor-pointer rounded-sm px-2 py-1.5 text-sm',
+                i === active && 'bg-muted',
+              )}
+              onMouseEnter={() => setActive(i)}
+              onMouseDown={(e) => {
+                e.preventDefault()
+                choose(opt)
+              }}
+            >
+              {opt.label}
+            </li>
+          ))}
+        </ul>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+export function ComboboxField({ field }: { field: ComboboxFieldSpec }) {
+  const { control, wrapperProps } = useFieldState(field)
+  const config = useRdfConfig()
+  const loader = config.asyncOptions?.[field.name]
+  return (
+    <FieldWrapper {...wrapperProps}>
+      <Controller
+        control={control}
+        name={field.name}
+        render={({ field: rhf }) => (
+          <ComboboxControl
+            id={field.name}
+            placeholder={field.placeholder ?? 'Select…'}
+            staticOptions={field.options}
+            loader={loader}
+            value={rhf.value}
+            onChange={rhf.onChange}
+            onBlur={rhf.onBlur}
+          />
+        )}
+      />
+    </FieldWrapper>
+  )
+}

--- a/packages/ui/src/fields/field-resolver.tsx
+++ b/packages/ui/src/fields/field-resolver.tsx
@@ -1,4 +1,4 @@
-import type { FieldSpec, ShowIfRule } from '@rogeroliveira84/react-dynamic-forms'
+import type { FieldSpec, ComboboxFieldSpec, ShowIfRule } from '@rogeroliveira84/react-dynamic-forms'
 import { useWatch } from 'react-hook-form'
 import { TextField } from './text-field'
 import { NumberField } from './number-field'
@@ -11,6 +11,8 @@ import { SliderField } from './slider-field'
 import { ObjectField } from './object-field'
 import { ArrayField } from './array-field'
 import { FileField } from './file-field'
+import { ComboboxField } from './combobox-field'
+import { useRdfConfig } from './rdf-config'
 
 function renderField(field: FieldSpec) {
   switch (field.kind) {
@@ -35,6 +37,8 @@ function renderField(field: FieldSpec) {
       return <EnumField field={field} />
     case 'multi-enum':
       return <MultiEnumField field={field} />
+    case 'combobox':
+      return <ComboboxField field={field} />
     case 'object':
       return <ObjectField field={field} />
     case 'array':
@@ -51,7 +55,14 @@ function ConditionalField({ field, rule }: { field: FieldSpec; rule: ShowIfRule 
 }
 
 export function FieldResolver({ field }: { field: FieldSpec }) {
+  const { asyncOptions } = useRdfConfig()
   if (field.hidden) return null
   if (field.showIf) return <ConditionalField field={field} rule={field.showIf} />
+  // A registered async loader upgrades any field into a searchable async combobox.
+  if (asyncOptions?.[field.name] && field.kind !== 'combobox') {
+    const { kind: _kind, ...rest } = field
+    const upgraded = { ...rest, kind: 'combobox' } as ComboboxFieldSpec
+    return <ComboboxField field={upgraded} />
+  }
   return renderField(field)
 }

--- a/packages/ui/src/fields/rdf-config.tsx
+++ b/packages/ui/src/fields/rdf-config.tsx
@@ -1,0 +1,17 @@
+import { createContext, useContext } from 'react'
+import type { EnumOption } from '@rogeroliveira84/react-dynamic-forms'
+
+/** Map of field name → async options loader. Supplied at render time on `<DynamicForm>`. */
+export type AsyncOptionsMap = Record<string, (query: string) => Promise<EnumOption[]>>
+
+export type RdfConfig = {
+  asyncOptions?: AsyncOptionsMap
+}
+
+const RdfConfigContext = createContext<RdfConfig>({})
+
+export const RdfConfigProvider = RdfConfigContext.Provider
+
+export function useRdfConfig(): RdfConfig {
+  return useContext(RdfConfigContext)
+}

--- a/packages/ui/src/form-wizard.test.tsx
+++ b/packages/ui/src/form-wizard.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { z } from 'zod'
+import { FormWizard } from './form-wizard'
+import { DynamicForm } from './dynamic-form'
+
+const schema = z.object({
+  email: z.string().email(),
+  name: z.string().min(1),
+})
+const steps = [
+  { title: 'Account', fields: ['email'] },
+  { title: 'Profile', fields: ['name'] },
+]
+
+describe('<FormWizard>', () => {
+  it('renders only the first step initially', () => {
+    render(<FormWizard schema={schema} steps={steps} onSubmit={() => {}} />)
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument()
+    expect(screen.queryByLabelText(/^name/i)).not.toBeInTheDocument()
+  })
+
+  it('blocks Next while the current step is invalid', async () => {
+    render(<FormWizard schema={schema} steps={steps} onSubmit={() => {}} />)
+    await userEvent.type(screen.getByLabelText(/email/i), 'bad')
+    await userEvent.click(screen.getByRole('button', { name: /next/i }))
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument()
+    expect(screen.queryByLabelText(/^name/i)).not.toBeInTheDocument()
+  })
+
+  it('advances to the next step when the current step is valid', async () => {
+    render(<FormWizard schema={schema} steps={steps} onSubmit={() => {}} />)
+    await userEvent.type(screen.getByLabelText(/email/i), 'a@b.com')
+    await userEvent.click(screen.getByRole('button', { name: /next/i }))
+    expect(await screen.findByLabelText(/^name/i)).toBeInTheDocument()
+  })
+
+  it('keeps values when going Back', async () => {
+    render(<FormWizard schema={schema} steps={steps} onSubmit={() => {}} />)
+    await userEvent.type(screen.getByLabelText(/email/i), 'a@b.com')
+    await userEvent.click(screen.getByRole('button', { name: /next/i }))
+    await userEvent.click(await screen.findByRole('button', { name: /back/i }))
+    expect((screen.getByLabelText(/email/i) as HTMLInputElement).value).toBe('a@b.com')
+  })
+
+  it('submits on the last step with all values', async () => {
+    const onSubmit = vi.fn()
+    render(<FormWizard schema={schema} steps={steps} onSubmit={onSubmit} />)
+    await userEvent.type(screen.getByLabelText(/email/i), 'a@b.com')
+    await userEvent.click(screen.getByRole('button', { name: /next/i }))
+    await userEvent.type(await screen.findByLabelText(/^name/i), 'Roger')
+    await userEvent.click(screen.getByRole('button', { name: /submit/i }))
+    expect(onSubmit).toHaveBeenCalled()
+    expect(onSubmit.mock.calls[0]?.[0]).toMatchObject({ email: 'a@b.com', name: 'Roger' })
+  })
+
+  it('is exposed as the compound component DynamicForm.Wizard', () => {
+    expect(DynamicForm.Wizard).toBe(FormWizard)
+  })
+
+  it('warns when steps do not cover all schema fields', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    render(<FormWizard schema={schema} steps={[{ fields: ['email'] }]} onSubmit={() => {}} />)
+    expect(warn).toHaveBeenCalled()
+    warn.mockRestore()
+  })
+})

--- a/packages/ui/src/form-wizard.tsx
+++ b/packages/ui/src/form-wizard.tsx
@@ -1,0 +1,127 @@
+import { useEffect, useMemo, useState } from 'react'
+import { FormProvider, type FieldValues, type SubmitHandler, type DefaultValues } from 'react-hook-form'
+import {
+  useDynamicForm,
+  type SchemaInput,
+  type RdfLocaleInput,
+  type RdfMessages,
+} from '@rogeroliveira84/react-dynamic-forms'
+import { Button } from './primitives/button'
+import { FieldResolver } from './fields/field-resolver'
+import { RdfConfigProvider, type AsyncOptionsMap } from './fields/rdf-config'
+import { cn } from './utils/cn'
+
+export type WizardStep = {
+  title?: string
+  description?: string
+  fields: string[]
+}
+
+export type FormWizardProps<TValues extends FieldValues = FieldValues> = {
+  schema: SchemaInput
+  steps: WizardStep[]
+  onSubmit: SubmitHandler<TValues>
+  defaultValues?: DefaultValues<TValues>
+  onStepChange?: (index: number) => void
+  labels?: { next?: string; back?: string; submit?: string }
+  locale?: RdfLocaleInput
+  messages?: RdfMessages
+  asyncOptions?: AsyncOptionsMap
+  className?: string
+}
+
+export function FormWizard<TValues extends FieldValues = FieldValues>(props: FormWizardProps<TValues>) {
+  const { form, internalSchema } = useDynamicForm<TValues>({
+    schema: props.schema,
+    defaultValues: props.defaultValues,
+    locale: props.locale,
+    messages: props.messages,
+  })
+  const [step, setStep] = useState(0)
+
+  const fieldsByName = useMemo(
+    () => new Map(internalSchema.fields.map((f) => [f.name, f])),
+    [internalSchema],
+  )
+
+  // Guard: every schema field should live in some step, or it silently blocks submit.
+  useEffect(() => {
+    const covered = new Set(props.steps.flatMap((s) => s.fields))
+    const missing = internalSchema.fields.map((f) => f.name).filter((n) => !covered.has(n))
+    if (missing.length > 0) {
+      console.warn(
+        `[react-dynamic-forms] <DynamicForm.Wizard>: these fields are not in any step and will block submit: ${missing.join(', ')}`,
+      )
+    }
+  }, [props.steps, internalSchema])
+
+  const current = props.steps[step]
+  const isLast = step === props.steps.length - 1
+  const stepFields = (current?.fields ?? [])
+    .map((name) => fieldsByName.get(name))
+    .filter((f): f is NonNullable<typeof f> => Boolean(f))
+
+  const changeStep = (next: number) => {
+    setStep(next)
+    props.onStepChange?.(next)
+  }
+
+  const goNext = async () => {
+    const names = current?.fields ?? []
+    const ok = await form.trigger(names as Parameters<typeof form.trigger>[0])
+    if (ok) changeStep(Math.min(step + 1, props.steps.length - 1))
+  }
+
+  return (
+    <RdfConfigProvider value={{ asyncOptions: props.asyncOptions }}>
+    <FormProvider {...form}>
+      <form
+        onSubmit={form.handleSubmit(props.onSubmit)}
+        className={cn('flex flex-col gap-4', props.className)}
+        noValidate
+      >
+        <div
+          className="flex items-center gap-1.5"
+          role="progressbar"
+          aria-valuenow={step + 1}
+          aria-valuemin={1}
+          aria-valuemax={props.steps.length}
+          aria-label={`Step ${step + 1} of ${props.steps.length}`}
+        >
+          {props.steps.map((s, i) => (
+            <div
+              key={s.title ?? i}
+              className={cn('h-1.5 flex-1 rounded-full', i <= step ? 'bg-primary' : 'bg-muted')}
+            />
+          ))}
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Step {step + 1} of {props.steps.length}
+        </p>
+
+        {current?.title && <h2 className="text-lg font-semibold">{current.title}</h2>}
+        {current?.description && (
+          <p className="text-sm text-muted-foreground">{current.description}</p>
+        )}
+
+        {stepFields.map((f) => (
+          <FieldResolver key={f.name} field={f} />
+        ))}
+
+        <div className="mt-2 flex justify-between">
+          <Button type="button" variant="outline" onClick={() => changeStep(Math.max(step - 1, 0))} disabled={step === 0}>
+            {props.labels?.back ?? 'Back'}
+          </Button>
+          {isLast ? (
+            <Button type="submit">{props.labels?.submit ?? 'Submit'}</Button>
+          ) : (
+            <Button type="button" onClick={goNext}>
+              {props.labels?.next ?? 'Next'}
+            </Button>
+          )}
+        </div>
+      </form>
+    </FormProvider>
+    </RdfConfigProvider>
+  )
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,8 +1,15 @@
 export { DynamicForm, type DynamicFormProps } from './dynamic-form'
+export { FormWizard, type FormWizardProps, type WizardStep } from './form-wizard'
 
 export { FieldResolver } from './fields/field-resolver'
 export { FieldWrapper, type FieldWrapperProps } from './fields/field-wrapper'
 export { useFieldState, type FieldState } from './fields/use-field-state'
+export {
+  RdfConfigProvider,
+  useRdfConfig,
+  type RdfConfig,
+  type AsyncOptionsMap,
+} from './fields/rdf-config'
 
 export { TextField } from './fields/text-field'
 export { NumberField } from './fields/number-field'
@@ -15,6 +22,7 @@ export { SliderField } from './fields/slider-field'
 export { ObjectField } from './fields/object-field'
 export { ArrayField } from './fields/array-field'
 export { FileField } from './fields/file-field'
+export { ComboboxField } from './fields/combobox-field'
 
 export { Input } from './primitives/input'
 export { Label } from './primitives/label'
@@ -30,5 +38,6 @@ export {
 export { Switch } from './primitives/switch'
 export { Textarea } from './primitives/textarea'
 export { Slider } from './primitives/slider'
+export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor } from './primitives/popover'
 
 export { cn } from './utils/cn'

--- a/packages/ui/src/primitives/popover.tsx
+++ b/packages/ui/src/primitives/popover.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react'
+import * as PopoverPrimitive from '@radix-ui/react-popover'
+import { cn } from '../utils/cn'
+
+export const Popover = PopoverPrimitive.Root
+export const PopoverTrigger = PopoverPrimitive.Trigger
+export const PopoverAnchor = PopoverPrimitive.Anchor
+
+export const PopoverContent = React.forwardRef<
+  React.ElementRef<typeof PopoverPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
+>(({ className, align = 'start', sideOffset = 4, ...props }, ref) => (
+  <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        'z-50 w-[var(--radix-popover-trigger-width)] rounded-md border bg-popover p-1 text-popover-foreground shadow-md outline-none',
+        className,
+      )}
+      {...props}
+    />
+  </PopoverPrimitive.Portal>
+))
+PopoverContent.displayName = 'PopoverContent'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -214,6 +214,9 @@ importers:
       '@radix-ui/react-label':
         specifier: ^2.1.0
         version: 2.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-popover':
+        specifier: ^1.1.2
+        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@radix-ui/react-select':
         specifier: ^2.1.2
         version: 2.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -1408,6 +1411,19 @@ packages:
 
   '@radix-ui/react-label@2.1.8':
     resolution: {integrity: sha512-FmXs37I6hSBVDlO4y764TNz1rLgKwjJMQ0EGte6F3Cb3f4bIuHB/iLa/8I9VKkmOy+gNHq8rql3j686ACVV21A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-popover@1.1.15':
+    resolution: {integrity: sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -4554,6 +4570,29 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
+      aria-hidden: 1.2.6
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.5)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)


### PR DESCRIPTION
## Power features — wizard, async combobox, i18n

Adds the three remaining roadmap features to `core` + `ui`. All additive, fully backward compatible, TDD throughout.

### 🧙 Multi-step wizard
`<DynamicForm.Wizard steps={[...]}>` (also exported as `FormWizard`). One underlying form across steps; **Next** validates only the current step's fields via `form.trigger` and won't advance while invalid. Built-in progress indicator and a dev warning when steps don't cover all fields. Zero new deps.

### 🔎 Combobox (with async options)
New `combobox` field kind (core type + adapters + zod builder). `<DynamicForm asyncOptions={{ field: loader }}>` upgrades any field — even a plain `z.string()` — into a searchable, debounced, keyboard-navigable async combobox. JSON Schema detection via the `x-rdf-combobox` extension. One new dependency: `@radix-ui/react-popover`.

### 🌍 i18n
`locale="pt-BR"` localizes every validation message without touching the schema (implemented as a Zod `errorMap`). Built-in `en` / `pt-BR` / `es`, per-key `messages` overrides, and explicit schema messages still win. Works for Zod, JSON Schema, and legacy inputs alike.

### Verification
- **Tests:** 105 passing (core 71 · ui 18 · ai 16)
- **Build:** 5/5 packages · UI 32.25 KB (+10 KB from combobox/popover)
- **Typecheck:** clean · **Lint:** clean

### Notes
- Changeset included (`minor` for `core` + `ui`, which are linked).
- Demo (`apps/demo`) gains wizard, async-combobox, and pt-BR examples.
- README + README.pt-br updated to document the new features; AI content removed (the `ai` package is parked and unpublished).
- `ai` package emitters updated for the new `combobox` kind (FieldKind exhaustiveness).

Spec: `docs/superpowers/specs/2026-06-05-rdf-power-features-design.md`